### PR TITLE
Limits & Skips should not be arrays

### DIFF
--- a/models/datasources/mongodb_source.php
+++ b/models/datasources/mongodb_source.php
@@ -899,9 +899,14 @@ class MongodbSource extends DboSource {
  */
 	protected function _setEmptyArrayIfEmpty($data) {
 		if (is_array($data)) {
+			$offsets = array('limit', 'offset');
 			foreach($data as $key => $value) {
 				if (empty($value)) {
-					$data[$key] = array();
+					if (in_array($key, $offsets)) {
+						$data[$key] = 0;
+					} else {
+						$data[$key] = array();
+					}
 				}
 			}
 			return $data;


### PR DESCRIPTION
Doing a call like $this->Post->find('all'); would fail due to the method MongoDBSource::_setEmptyArrayIfEmpty() turning limit and skip into an array when in fact it should be 0 to represent an infinite limit & no skip.
