### PR TITLE
getDb() getter

### DIFF
--- a/models/datasources/mongodb_source.php
+++ b/models/datasources/mongodb_source.php
@@ -221,6 +221,10 @@ class MongodbSource extends DboSource {
 		}
 		return true;
 	}
+	
+	public function getDb() {
+		return $this->_db;
+	}
 
 /**
  * Get list of available Collections


### PR DESCRIPTION
Just added a getDb() getter for retrieving the MongoDB instance, I found this to be neccessary already for making distinct queries and I couldnt find a way to get it.

If I have time I will look into contributing a patch that enables distinct queries. The problem is that you have to go over the db.command() method to achieve this right now.
