### PR TITLE
Support inline out for Map Reduce

### DIFF
--- a/models/datasources/mongodb_source.php
+++ b/models/datasources/mongodb_source.php
@@ -1099,11 +1099,25 @@ class MongodbSource extends DboSource {
 		}
 
 		$result = $this->query($query);
-		if($result['ok']) {
-			$data = $this->_db->selectCollection($result['result'])->find();
-			if(!empty($timeout)) {
-				$data->timeout($timeout);
-			}
+  	if($result['ok']) {
+      if (isset($query['out']['inline']) && $query['out']['inline'] == 1)
+      {
+        if (is_array($result['results']))
+        {
+          $data = current($result['results']);
+        }
+        else
+        {
+          $data = false;
+        }
+      }
+      else
+      {
+			  $data = $this->_db->selectCollection($result['result'])->find();
+			  if(!empty($timeout)) {
+				  $data->timeout($timeout);
+			  }
+      }
 			return $data;
 		}
 		return false;


### PR DESCRIPTION
Add support in mapReduce for out => inline = 1, where the mapReduce does not go into a collection. The results are passed back immediately. See http://www.mongodb.org/display/DOCS/MapReduce under "Output Options"
