### PR TITLE
Full debug record count ignores limits in 'public function read'

### DIFF
--- a/models/datasources/mongodb_source.php
+++ b/models/datasources/mongodb_source.php
@@ -976,7 +976,7 @@ class MongodbSource extends DboSource {
 				->limit($limit)
 				->skip($offset);
 			if ($this->fullDebug) {
-				$count = $return->count();
+				$count = $return->count(true);
 				$this->logQuery("db.{$Model->useTable}.find( :conditions, :fields ).sort( :order ).limit( :limit ).skip( :offset )",
 					compact('conditions', 'fields', 'order', 'limit', 'offset', 'count')
 				);


### PR DESCRIPTION
Changing $return->count(); to $return->count(true); makes it respect limits.

From : http://www.php.net/manual/en/mongocursor.count.php
Parameters
foundOnly (bool)
Send cursor limit and skip information to the count function, if applicable.
