### PR TITLE
Replica Sets and setSlaveOk

### DIFF
--- a/models/datasources/mongodb_source.php
+++ b/models/datasources/mongodb_source.php
@@ -180,12 +180,15 @@ class MongodbSource extends DboSource {
 
 			if (isset($this->config['replicaset']) && count($this->config['replicaset']) === 2) {
 				$this->connection = new Mongo($this->config['replicaset']['host'], $this->config['replicaset']['options']);
+				if (isset($this->config['slaveok'])) {
+					$this->connection->setSlaveOk($this->config['slaveok']);
+				}
 			} else if ($this->_driverVersion >= '1.2.0') {
 				$this->connection = new Mongo($host, array("persist" => $this->config['persistent']));
 			} else {
 				$this->connection = new Mongo($host, true, $this->config['persistent']);
 			}
-
+			
 			if ($this->_db = $this->connection->selectDB($this->config['database'])) {
 				if (!empty($this->config['login']) && $this->_driverVersion < '1.2.0') {
 					$return = $this->_db->authenticate($this->config['login'], $this->config['password']);


### PR DESCRIPTION
Add support for Mongo::setSlaveOk to allow a connection using a replica set to determine whether reads are OK to be read from slaves.

I've tried to keep the coding style similar to the current code - lower case config option, starting `{` on the same line as the `if` :)
