### PR TITLE
Several changes; read below.

### DIFF
--- a/models/datasources/mongodb_source.php
+++ b/models/datasources/mongodb_source.php
@@ -1024,7 +1024,7 @@ class MongodbSource extends DboSource {
 				'query' => $conditions,
 				'sort' => $order,
 				'remove' => !empty($remove),
-				'update' => array('$set' => $modify),
+				'update' => $this->setMongoUpdateOperator($Model, $modify),
 				'new' => !empty($new),
 				'fields' => $fields,
 				'upsert' => !empty($upsert)

--- a/models/datasources/mongodb_source.php
+++ b/models/datasources/mongodb_source.php
@@ -944,6 +944,13 @@ class MongodbSource extends DboSource {
 		extract($query);
 
 		if (!empty($order[0])) {
+			if (is_string($order[0])) {
+				$order = explode(' ', $order[0]);
+				if (empty($order[1])) {
+					$order[1] = 'ASC';
+				}
+				$order = array(array($order[0] => $order[1]));
+			}
 			$order = array_shift($order);
 		}
 		$this->_stripAlias($conditions, $Model->alias);

--- a/models/datasources/mongodb_source.php
+++ b/models/datasources/mongodb_source.php
@@ -394,8 +394,7 @@ class MongodbSource extends DboSource {
 		$Model->primaryKey = '_id';
 		$schema = array();
 		if (!empty($Model->mongoSchema) && is_array($Model->mongoSchema)) {
-			$schema = $Model->mongoSchema;
-			return $schema + $this->_defaultSchema;
+			return $Model->mongoSchema;
 		} elseif ($this->isConnected() && is_a($Model, 'Model') && !empty($Model->Behaviors)) {
 			$Model->Behaviors->attach('Mongodb.Schemaless');
 			if (!$Model->data) {


### PR DESCRIPTION
Here are the changes done:
1. Transforming a Model's $order attribute from a string to an array, so that it gets set (addresses the issue brought here: https://github.com/ichikaway/cakephp-mongodb/issues/20).
2. Adds the ability to set update operators (using mongoNoSetOperator) on findAndModify queries (i.e. 'De-hardcodes' the '$set' parameter).
3. Makes the 'created' and 'modified' keys optional: if $mongoSchema is defined without these keys, they won't be added.
   (Sometimes one doesn't need these keys and wishes to eliminate them to improve performance a bit, but the MongoDB Datasource kept adding them no matter what).
