### PR TITLE
strict type juggling proposal

### DIFF
--- a/Model/Datasource/MongodbSource.php
+++ b/Model/Datasource/MongodbSource.php
@@ -452,6 +452,9 @@ class MongodbSource extends DboSource {
 		} else {
 			$data = $Model->data;
 		}
+		foreach ($data as $field => $value) {
+			$data[$field] = $this->value($value, $Model->getColumnType($field));
+		}
 		if (!empty($data['_id'])) {
 			$this->_convertId($data['_id']);
 		}
@@ -1159,12 +1162,19 @@ class MongodbSource extends DboSource {
  * @return mixed Prepared value or array of values.
  * @access public
  */
-	public function value($data, $column = null, $read = true) {
-		$return = parent::value($data, $column, $read);
+	public function value($data, $column = null) {
+		/*
+		$return = parent::value($data, $column);
 		if ($return === null && $data !== null) {
 			return $data;
 		}
-		return $return;
+		 *
+		 */
+		if ($column == 'integer') {
+			return intval($data);
+		}
+		
+		return $data;
 	}
 
 /**

--- a/Model/Datasource/MongodbSource.php
+++ b/Model/Datasource/MongodbSource.php
@@ -1154,26 +1154,22 @@ class MongodbSource extends DboSource {
 
 
 /**
- * Prepares a value, or an array of values for database queries by quoting and escaping them.
+ * Prepares a value
+ *
+ * From CakePHP: "Returns a quoted and escaped string of $data for use in an SQL statement."
+ *
+ * For MongodbSource: Casts type into that defined in the schema using appropriate formatter
  *
  * @param mixed $data A value or an array of values to prepare.
- * @param string $column The column into which this data will be inserted
- * @param boolean $read Value to be used in READ or WRITE context
+ * @param string $column The column data type
  * @return mixed Prepared value or array of values.
  * @access public
  */
 	public function value($data, $column = null) {
-		/*
-		$return = parent::value($data, $column);
-		if ($return === null && $data !== null) {
-			return $data;
+		$ignore = array('date', 'datetime', 'timestamp', 'time'); // Model::save only juggles date types?
+		if (!in_array($column, $ignore) && isset($this->columns[$column]['formatter'])) {
+			return $this->columns[$column]['formatter']($data);
 		}
-		 *
-		 */
-		if ($column == 'integer') {
-			return intval($data);
-		}
-		
 		return $data;
 	}
 

--- a/Test/Case/Datasource/MongodbSourceTest.php
+++ b/Test/Case/Datasource/MongodbSourceTest.php
@@ -439,6 +439,59 @@ class MongodbSourceTest extends CakeTestCase {
 		$this->assertTrue(is_a($resultData['modified'], 'MongoDate'));
 	}
 
+
+/**
+ * Test data types after storage
+ * http://php.net/manual/en/class.mongodb.php
+ *
+ * @return void
+ * @access public
+ */
+	public function testTypesAfterSave() {
+		$data = array(
+			'title' => 'test',
+			'body' => 'aaaa',
+			'text' => 'bbbb',
+			'count' => 4 // native PHP Mongo casting
+		);
+		$saveData['Post'] = $data;
+
+		$this->Post->create();
+		$saveResult = $this->Post->save($saveData);
+		$this->assertTrue(!empty($saveResult) && is_array($saveResult));
+
+		$result = $this->Post->find('all');
+
+		$this->assertEqual(1, count($result));
+		$resultData = $result[0]['Post'];
+
+		$this->assertEqual(7, count($resultData));
+		$this->assertTrue($resultData['count'] === 4);
+		$this->assertFalse($resultData['count'] === '4');
+
+		$data = array(
+			'title' => 'test',
+			'body' => 'aaaa',
+			'text' => 'bbbb',
+			'count' => '4' // force type cast by schema
+		);
+		$saveData['Post'] = $data;
+
+		$this->Post->create();
+		$saveResult = $this->Post->save($saveData);
+		$this->assertTrue(!empty($saveResult) && is_array($saveResult));
+
+		$result = $this->Post->find('all');
+
+		$this->assertEqual(2, count($result));
+		$resultData = $result[1]['Post'];
+
+		$this->assertEqual(7, count($resultData));
+		$this->assertTrue($resultData['count'] === 4);
+		$this->assertFalse($resultData['count'] === '4');
+	}
+
+
 /**
  * Tests insertId after saving
  *


### PR DESCRIPTION
It seems like Model's typing is not sufficiently strict enough for a doc db?  It appears to only cast date/time types.  See my tests...if my schema the field "count" defined as in integer I only want it stored in mongo as an integer.  Not a string.  
