### PR TITLE
Allow slaveOkay setting to be set outside of the replica set options

### DIFF
--- a/models/datasources/mongodb_source.php
+++ b/models/datasources/mongodb_source.php
@@ -180,15 +180,16 @@ class MongodbSource extends DboSource {
 
 			if (isset($this->config['replicaset']) && count($this->config['replicaset']) === 2) {
 				$this->connection = new Mongo($this->config['replicaset']['host'], $this->config['replicaset']['options']);
-				if (isset($this->config['slaveok'])) {
-					$this->connection->setSlaveOkay($this->config['slaveok']);
-				}
 			} else if ($this->_driverVersion >= '1.2.0') {
 				$this->connection = new Mongo($host, array("persist" => $this->config['persistent']));
 			} else {
 				$this->connection = new Mongo($host, true, $this->config['persistent']);
 			}
 			
+      if (isset($this->config['slaveok'])) {
+        $this->connection->setSlaveOkay($this->config['slaveok']);
+      }
+      
 			if ($this->_db = $this->connection->selectDB($this->config['database'])) {
 				if (!empty($this->config['login']) && $this->_driverVersion < '1.2.0') {
 					$return = $this->_db->authenticate($this->config['login'], $this->config['password']);


### PR DESCRIPTION
Previously the connection's slaveOkay setting was dependent on the replicaset config option, however this doesn't work when in a sharded environment as you connect to a mongos instance which routes stuff to the different shards/replica sets for you.

Setting the slaveOkay method outside of all the connection conditions allows for reading from slaves in either a sharded or a replicaset environment.
