### PR TITLE
Minor changes to be more compatible with latest 2.x version

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -24,11 +24,11 @@ To install the driver for use in any/multiple application(s)
 To use this DB driver, install (obviously) and define a db source such as follows:
 
 	<?php
-	//app/config/bootstrap.php
+	//app/Config/bootstrap.php
 	CakePlugin::loadAll();
 
 
-	// app/config/database.php
+	// app/Config/database.php
 	class DATABASE_CONFIG {
 		public $default = array(
 			'datasource' => 'Mongodb.MongodbSource',
@@ -46,6 +46,14 @@ To use this DB driver, install (obviously) and define a db source such as follow
 			*/
 		);
 	}
+	
+	// To make sure all tests are passing create the following entry in app/Config/database.php
+	public $test = array(
+		'datasource' => 'Mongodb.MongodbSource',
+    'database' => 'test_mongo',
+		'host' => 'localhost',
+		'port' => 27017,
+  ); 
 
 
 More detail of replicaset in wiki:

--- a/Test/Case/Behavior/SqlCompatibleTest.php
+++ b/Test/Case/Behavior/SqlCompatibleTest.php
@@ -95,7 +95,7 @@ class SqlCompatibleTest extends CakeTestCase {
 	public function startTest() {
 		$connections = ConnectionManager::enumConnectionObjects();
 
-		if (!empty($connections['test']['classname']) && $connections['test']['classname'] === 'mongodbSource') {
+		if (!empty($connections['test']['classname']) && $connections['test']['classname'] === 'mongodbSource') {		
 			$config = new DATABASE_CONFIG();
 			$this->_config = $config->test;
 		}
@@ -134,7 +134,8 @@ class SqlCompatibleTest extends CakeTestCase {
 			'fields' => array('_id', 'title', 'number'),
 			'order' => array('number' => 'ASC')
 		));
-		$result = Set::extract($result, '/Post/title');
+
+		$result = Hash::extract($result, '{n}.Post.title');
 		$this->assertEqual($expected, $result);
 
 		$conditions = array(
@@ -151,7 +152,7 @@ class SqlCompatibleTest extends CakeTestCase {
 			'fields' => array('_id', 'title', 'number'),
 			'order' => array('number' => 'ASC')
 		));
-		$result = Set::extract($result, '/Post/title');
+		$result = Hash::extract($result, '{n}.Post.title');
 		$this->assertEqual($expected, $result);
 
 		$conditions = array(
@@ -176,7 +177,7 @@ class SqlCompatibleTest extends CakeTestCase {
 			'fields' => array('_id', 'title', 'number'),
 			'order' => array('number' => 'ASC')
 		));
-		$result = Set::extract($result, '/Post/title');
+		$result = Hash::extract($result, '{n}.Post.title');
 		$this->assertEqual($expected, $result);
 
 		$conditions = array(
@@ -203,7 +204,7 @@ class SqlCompatibleTest extends CakeTestCase {
 			'fields' => array('_id', 'title', 'number'),
 			'order' => array('number' => 'ASC')
 		));
-		$result = Set::extract($result, '/Post/title');
+		$result = Hash::extract($result, '{n}.Post.title');
 		$this->assertEqual($expected, $result);
 
 		$conditions = array(
@@ -230,7 +231,7 @@ class SqlCompatibleTest extends CakeTestCase {
 			'fields' => array('_id', 'title', 'number'),
 			'order' => array('number' => 'ASC')
 		));
-		$result = Set::extract($result, '/Post/title');
+		$result = Hash::extract($result, '{n}.Post.title');
 		$this->assertEqual($expected, $result);
 
 		$conditions = array(
@@ -265,7 +266,7 @@ class SqlCompatibleTest extends CakeTestCase {
 		$result = $this->Post->find('all', $params);
 
 		$expected = array('A11','A12');
-		$result = Set::extract($result, '/Post/_id');
+		$result = Hash::extract($result, '{n}.Post._id');
 		$this->assertEqual($expected, $result);
 		$this->assertEqual(2, count($result));
 
@@ -280,7 +281,7 @@ class SqlCompatibleTest extends CakeTestCase {
 		$params = array('conditions' => array('_id' => array('$nin' => array('A11', 'A12'))));
 		$result = $this->Post->find('all', $params);
 		//$expected = array('A13','A14');
-		$result = Set::extract($result, '/Post/_id');
+		$result = Hash::extract($result, '{n}.Post._id');
 		$this->assertTrue(in_array('A13', $result));
 		$this->assertFalse(in_array('A11', $result));
 		$this->assertFalse(in_array('A12', $result));
@@ -309,7 +310,7 @@ class SqlCompatibleTest extends CakeTestCase {
 			'fields' => array('_id', 'title'),
 			'order' => array('title DESC')
 		));
-		$result = Set::extract($result, '/Post/title');
+		$result = Hash::extract($result, '{n}.Post.title');
 		$this->assertEqual($expected, $result);
 
 		$order = array(array('title' => 'DESC'));
@@ -329,7 +330,7 @@ class SqlCompatibleTest extends CakeTestCase {
 			'fields' => array('_id', 'title'),
 			'order' => array('title ASC')
 		));
-		$result = Set::extract($result, '/Post/title');
+		$result = Hash::extract($result, '{n}.Post.title');
 		$this->assertEqual($expected, $result);
 
 		$order = array(array('title' => 'ASC'));
@@ -350,7 +351,7 @@ class SqlCompatibleTest extends CakeTestCase {
 			'fields' => array('_id', 'title'),
 			'order' => array('Post.title DESC')
 		));
-		$result = Set::extract($result, '/Post/title');
+		$result = Hash::extract($result, '{n}.Post.title');
 		$this->assertEqual($expected, $result);
 	}
 

--- a/Test/Case/Datasource/MongodbSourceTest.php
+++ b/Test/Case/Datasource/MongodbSourceTest.php
@@ -1263,28 +1263,28 @@ public function testMapReduce() {
 			'fields' => array('_id', 'title'),
 			'order' => array('title' => 1)
 		));
-		$result = Set::extract($result, '/Post/title');
+		$result = Hash::extract($result, '{n}.Post.title');
 
 		$this->assertEqual($expected, $result);
 		$result = $this->Post->find('all', array(
 			'fields' => array('_id', 'title'),
 			'order' => array('title' => 'ASC')
 		));
-		$result = Set::extract($result, '/Post/title');
+		$result = Hash::extract($result, '{n}.Post.title');
 
 		$expected = array_reverse($expected);
 		$result = $this->Post->find('all', array(
 			'fields' => array('_id', 'title'),
 			'order' => array('title' => '-1')
 		));
-		$result = Set::extract($result, '/Post/title');
+		$result = Hash::extract($result, '{n}.Post.title');
 		$this->assertEqual($expected, $result);
 
 		$result = $this->Post->find('all', array(
 			'fields' => array('_id', 'title'),
 			'order' => array('title' => 'DESC')
 		));
-		$result = Set::extract($result, '/Post/title');
+		$result = Hash::extract($result, '{n}.Post.title');
 		$this->assertEqual($expected, $result);
 	}
 


### PR DESCRIPTION
Adjusted capitalization in README
Added sample for $test configuration
Replace deprecated Set::extract() with newer Hash::extract() 
