### PR TITLE
Added support for MongoDB aggregation framework to the datasource

### DIFF
--- a/Model/Datasource/MongodbSource.php
+++ b/Model/Datasource/MongodbSource.php
@@ -1076,8 +1076,13 @@ class MongodbSource extends DboSource {
                 if(!empty($order)) {
                     $conditions['aggregate'][] = array('$sort' => $order);
                 }
-                $conditions['aggregate'][] = array('$skip' => $offset);
-                $conditions['aggregate'][] = array('$limit' => $limit);
+                if (!empty($offset)) {
+                    $conditions['aggregate'][] = array('$skip' => $offset);
+                }
+                if(!empty($limit))
+                {
+                    $conditions['aggregate'][] = array('$limit' => $limit);
+                }
 
                 $return = $this->_db
                     ->selectCollection($Model->table)

--- a/Model/Datasource/MongodbSource.php
+++ b/Model/Datasource/MongodbSource.php
@@ -987,6 +987,7 @@ class MongodbSource extends DboSource {
  * @access public
  */
 	public function read(Model $Model, $query = array(), $recursive = null) {
+        $isAggregateQuery = false;
 		if (!$this->isConnected()) {
 			return false;
 		}
@@ -1039,14 +1040,28 @@ class MongodbSource extends DboSource {
 			$offset = ($page - 1) * $limit;
 		}
 
+        // Set flag if the query is an aggregate query.
+        if( count($conditions) == 1 && array_key_exists('aggregate', $conditions))
+        {
+            $isAggregateQuery = true;
+        }
+
 		$return = array();
 
 		$this->_prepareLogQuery($Model); // just sets a timer
 		if (empty($modify)) {
 			if ($Model->findQueryType === 'count' && $fields == array('count' => true)) {
-				$count = $this->_db
-					->selectCollection($Model->table)
-					->count($conditions);
+                if($isAggregateQuery) {
+                    $count = $this->getResultCountForAggregateQuery($Model, $conditions);
+                }
+                else
+                {
+                    $count = $this->_db
+                        ->selectCollection($Model->table)
+                        ->count($conditions);
+                }
+
+
 				if ($this->fullDebug) {
 					$this->logQuery("db.{$Model->useTable}.count( :conditions )",
 						compact('conditions', 'count')
@@ -1055,18 +1070,51 @@ class MongodbSource extends DboSource {
 				return array(array($Model->alias => array('count' => $count)));
 			}
 
-			$return = $this->_db
-				->selectCollection($Model->table)
-				->find($conditions, $fields)
-				->sort($order)
-				->limit($limit)
-				->skip($offset);
-			if ($this->fullDebug) {
-				$count = $return->count(true);
-				$this->logQuery("db.{$Model->useTable}.find( :conditions, :fields ).sort( :order ).limit( :limit ).skip( :offset )",
-					compact('conditions', 'fields', 'order', 'limit', 'offset', 'count')
-				);
-			}
+            if($isAggregateQuery)
+            {
+                //We are dealing with aggregate query here.
+                if(!empty($order)) {
+                    $conditions['aggregate'][] = array('$sort' => $order);
+                }
+                $conditions['aggregate'][] = array('$skip' => $offset);
+                $conditions['aggregate'][] = array('$limit' => $limit);
+
+                $return = $this->_db
+                    ->selectCollection($Model->table)
+                    ->aggregate($conditions['aggregate']);
+
+                //Format $return in a format that cake expects
+                $_return = array();
+                foreach($return['result'] as $result)
+                {
+                    $_return[][$Model->alias] = $result;
+                }
+                $return = $_return;
+            }
+            else
+            {
+                $return = $this->_db
+                    ->selectCollection($Model->table)
+                    ->find($conditions, $fields)
+                    ->sort($order)
+                    ->limit($limit)
+                    ->skip($offset);
+            }
+
+
+            if ($this->fullDebug) {
+                if($isAggregateQuery)
+                {
+                    $count = $this->getResultCountForAggregateQuery($Model,$conditions);
+                }
+                else
+                {
+                    $count = $return->count(true);
+                }
+                $this->logQuery("db.{$Model->useTable}.find( :conditions, :fields ).sort( :order ).limit( :limit ).skip( :offset )",
+                    compact('conditions', 'fields', 'order', 'limit', 'offset', 'count')
+                );
+            }
 		} else {
 			$options = array_filter(array(
 				'findandmodify' => $Model->table,
@@ -1096,9 +1144,16 @@ class MongodbSource extends DboSource {
 			}
 		}
 
-		if ($Model->findQueryType === 'count') {
-			return array(array($Model->alias => array('count' => $return->count())));
-		}
+        if ($Model->findQueryType === 'count') {
+            if($isAggregateQuery) {
+                $count = $this->getResultCountForAggregateQuery($Model,$conditions);
+            }
+            else
+            {
+                $count = $return->count();
+            }
+            return array(array($Model->alias => array('count' => $count)));
+        }
 
 		if (is_object($return)) {
 			$_return = array();
@@ -1118,6 +1173,32 @@ class MongodbSource extends DboSource {
 		}
 		return $return;
 	}
+
+    /**
+     * @param $Model
+     * @param $conditions
+     * @return int
+     */
+    protected function getResultCountForAggregateQuery(&$Model, $conditions)
+    {
+        $countConditions = $conditions['aggregate'];
+        $countConditions[] = array(
+            '$group' => array(
+                '_id' => null,
+                'count' => array('$sum' => 1)
+            ));
+        $countOfAggregatedResults = $this->_db
+            ->selectCollection($Model->table)
+            ->aggregate($countConditions);
+
+        if (!empty($countOfAggregatedResults['result'])) {
+            $countOfAggregatedResults = $countOfAggregatedResults['result'][0]['count'];
+        } else {
+            $countOfAggregatedResults = 0;
+        }
+        $count = $countOfAggregatedResults;
+        return $count;
+    }
 
 /**
  * rollback method


### PR DESCRIPTION
Now, we can pass something like:

$conditions = array(
    'aggregate' => array(
        array(
            '$match' => array(
                'refNo' => 1,
                'date' => array(
                    '$gte' => '2013-03-30',
                    '$lte' => '2013-04-30'
                )
            )
        ),
        array(
            '$group' => array(
                '_id' => '$product',
                'count' => array(
                    '$sum' => '$count'
                )
            )
        ),
        array(
            '$project' => array(
                'product' => '$_id',
                'count' => 1
            )
        )
    )
)

to the paginate or find method. It is the same array as you would pass to the MongoDB aggregate method for the PHP driver.

Fully works with pagination.
