### PR TITLE
Add composer support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,53 @@
+{
+    "name": "ichikaway/cakephp-mongodb",
+    "description": "MongoDB Datasource for CakePHP",
+    "type": "cakephp-plugin",
+    "keywords": ["cakephp", "mongo", "datasource"],
+    "homepage": "https://github.com/ichikaway/cakephp-mongodb",
+    "authors": [
+        {
+            "name": "Yasushi Ichikawa",
+            "homepage": "http://twitter.com/ichikaway",
+            "role": "Author"
+        },
+        {
+            "name": "Andy Dawson",
+            "homepage": "http://twitter.com/AD7six",
+            "role": "Author"
+        },
+        {
+            "name": "predominant",
+            "homepage": "http://github.com/predominant/",
+            "role": "Contributor"
+        },
+        {
+            "name": "jrbasso",
+            "homepage": "http://github.com/jrbasso/",
+            "role": "Contributor"
+        },
+        {
+            "name": "tkyk",
+            "homepage": "http://github.com/tkyk/",
+            "role": "Contributor"
+        },
+        {
+            "name": "Various Others",
+            "homepage": "https://github.com/ichikaway/cakephp-mongodb/graphs/contributors"
+        }
+    ],
+    "support": {
+        "issues": "https://github.com/ichikaway/cakephp-mongodb/issues",
+        "source": "https://github.com/ichikaway/cakephp-mongodb"
+    },
+    "require": {
+        "php": ">=5.3.0",
+        "composer/installers": "*"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-cake2.0": "2.0.x-dev",
+            "dev-cake2.2": "2.2.x-dev"
+        },
+        "installer-name": "Mongodb"
+    }
+}


### PR DESCRIPTION
This allows the plugin to be installed with composer using [composer installers](https://github.com/composer/installers). This ensures it gets loaded correctly into the `Plugin/` directory, and named according to the `installer-name` attribute. In this case `Mongodb`.

I've also added two branch aliases, as I can't seem to get versions to work with your current release tags.

I used the `composer.json` found in [CakePHP's Debug Kit](https://packagist.org/packages/cakephp/debug_kit) as a basis. It would also be wonderful if you could submit the package to the composer library for even easier installation.

Thanks for all your hard work and an excellent plugin.
