### PR TITLE
Makes SchemalessBehavior::beforeSave() compatible with ModelBehavior::be...

### DIFF
--- a/Model/Behavior/SchemalessBehavior.php
+++ b/Model/Behavior/SchemalessBehavior.php
@@ -81,7 +81,7 @@ class SchemalessBehavior extends ModelBehavior {
  * @return void
  * @access public
  */
-	public function beforeSave(Model $Model) {
+	public function beforeSave(Model $Model, $options = array()) {
 		$Model->cacheSources = false;
 		$Model->schema(true);
 		return true;


### PR DESCRIPTION
PHP 5.4+ Strict gives the following error when creating a form linked to a Model:

"Declaration of SchemalessBehavior::beforeSave() should be compatible with ModelBehavior::beforeSave(Model $model, $options = Array) [APP/Plugin/Mongodb/Model/Behavior/SchemalessBehavior.php, line 34]"

Added the $options argument for compatibility with parent class.
