### PR TITLE
Use setReadPreference() if setSlaveOkay() is not available

### DIFF
--- a/Model/Datasource/MongodbSource.php
+++ b/Model/Datasource/MongodbSource.php
@@ -203,7 +203,12 @@ class MongodbSource extends DboSource {
 			}
 
 			if (isset($this->config['slaveok'])) {
-				$this->connection->setSlaveOkay($this->config['slaveok']);
+				if (method_exists($this->connection, 'setSlaveOkay')) {
+					$this->connection->setSlaveOkay($this->config['slaveok']);
+				} else {
+					$this->connection->setReadPreference($this->config['slaveok']
+						? $class::RP_SECONDARY_PREFERRED : $class::RP_PRIMARY);
+				}
 			}
 
 			if ($this->_db = $this->connection->selectDB($this->config['database'])) {


### PR DESCRIPTION
setSlaveOkay() was deprecated in version 1.2.11 of the Mongo driver, and has now been removed from 1.4+, so we need to use setReadPreference() instead.

http://www.php.net/manual/en/mongo.readpreferences.php
