### PR TITLE
fixed ' needs an array' error when running find() against MongoDB 2.6

### DIFF
--- a/Model/Datasource/MongodbSource.php
+++ b/Model/Datasource/MongodbSource.php
@@ -1050,6 +1050,11 @@ class MongodbSource extends DboSource {
 		$this->_stripAlias($fields, $Model->alias, false, 'value');
 		$this->_stripAlias($order, $Model->alias, false, 'both');
 
+		array_walk($conditions, function(&$item, $key){
+			if (isset($item['$in']))
+				$item['$in'] = array_values($item['$in']);
+		});
+
 		if(!empty($conditions['id']) && empty($conditions['_id'])) {
 			$conditions['_id'] = $conditions['id'];
 			unset($conditions['id']);

--- a/Model/Datasource/MongodbSource.php
+++ b/Model/Datasource/MongodbSource.php
@@ -1050,10 +1050,10 @@ class MongodbSource extends DboSource {
 		$this->_stripAlias($fields, $Model->alias, false, 'value');
 		$this->_stripAlias($order, $Model->alias, false, 'both');
 
-		array_walk($conditions, function(&$item, $key){
-			if (isset($item['$in']))
-				$item['$in'] = array_values($item['$in']);
-		});
+		foreach ($conditions as $key => $values) {
+			if (isset($values['$in']))
+				$conditions[$key]['$in'] = array_values($values['$in']);
+		}
 
 		if(!empty($conditions['id']) && empty($conditions['_id'])) {
 			$conditions['_id'] = $conditions['id'];


### PR DESCRIPTION
See the problem here -> https://jira.mongodb.org/browse/PHP-1051
