### PR TITLE
changes made for cake 2.9 compatibility

### DIFF
--- a/Model/Datasource/MongodbSource.php
+++ b/Model/Datasource/MongodbSource.php
@@ -1313,10 +1313,11 @@ class MongodbSource extends DboSource {
  *
  * @param mixed $data A value or an array of values to prepare.
  * @param string $column The column into which this data will be inserted
+ * @param boolean $null available in DataSource cakePhp 2.9, Column allows NULL values
  * @return mixed Prepared value or array of values.
  * @access public
  */
-	public function value($data, $column = null) {
+	public function value($data, $column = NULL, $null = true) {
 		if (is_array($data) && !empty($data)) {
 			return array_map(
 				array(&$this, 'value'),
@@ -1473,7 +1474,7 @@ class MongodbSource extends DboSource {
 	public function logQuery($query, $args = array()) {
 		if ($args) {
 			$this->_stringify($args);
-			$query = String::insert($query, $args);
+			$query = CakeText::insert($query, $args);
 		}
 		$this->took = round((microtime(true) - $this->_startTime) * 1000, 0);
 		$this->affected = null;


### PR DESCRIPTION
### changes made according to cakePhp 2.9
> String class is deprecated in cake2.9 , added that change
> cake added allow NULL values to column , for that added one extra parameter in DboSource
> added same parameter in MongoDbSource to compatible with super class
**[ NOTE: You will need to create branch cake2.9 to merge this PR ]**